### PR TITLE
[17.0][FIX] sale_layout_category_hide_detail: fix bug cannot show sale report

### DIFF
--- a/sale_layout_category_hide_detail/README.rst
+++ b/sale_layout_category_hide_detail/README.rst
@@ -96,6 +96,7 @@ Contributors
 
 -  Denis Roussel <denis.roussel@acsone.eu>
 -  Jeroen Evens <jeroen.evens@dynapps.be>
+-  Tris Doan <tridm@trobz.com>
 
 Maintainers
 -----------

--- a/sale_layout_category_hide_detail/readme/CONTRIBUTORS.md
+++ b/sale_layout_category_hide_detail/readme/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
   - Yadier Quesada
 - Denis Roussel \<<denis.roussel@acsone.eu>\>
 - Jeroen Evens \<<jeroen.evens@dynapps.be>\>
+- Tris Doan \<<tridm@trobz.com>\>

--- a/sale_layout_category_hide_detail/static/description/index.html
+++ b/sale_layout_category_hide_detail/static/description/index.html
@@ -9,10 +9,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +276,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +302,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -436,12 +437,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li>Denis Roussel &lt;<a class="reference external" href="mailto:denis.roussel&#64;acsone.eu">denis.roussel&#64;acsone.eu</a>&gt;</li>
 <li>Jeroen Evens &lt;<a class="reference external" href="mailto:jeroen.evens&#64;dynapps.be">jeroen.evens&#64;dynapps.be</a>&gt;</li>
+<li>Tris Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_layout_category_hide_detail/views/invoice_report_templates.xml
+++ b/sale_layout_category_hide_detail/views/invoice_report_templates.xml
@@ -78,7 +78,7 @@
             />
       </xpath>
       <xpath
-            expr="//t[@t-foreach='lines']//span[contains(@t-out, 'line.tax_ids')]"
+            expr="//t[@t-foreach='lines']//span[contains(@t-out, 'taxes')]"
             position="attributes"
         >
         <attribute

--- a/sale_layout_category_hide_detail/views/sale_order_report_templates.xml
+++ b/sale_layout_category_hide_detail/views/sale_order_report_templates.xml
@@ -67,7 +67,7 @@
                                 t-if="current_section.show_section_subtotal"
                                 class="text-end"
                                 t-esc="current_subtotal"
-                                t-options='{"widget": "monetary", "display_currency": doc.pricelist_id.currency_id}'
+                                t-options='{"widget": "monetary", "display_currency": doc.currency_id}'
                             />
             </span>
           </td>

--- a/sale_layout_category_hide_detail/views/sale_portal_templates.xml
+++ b/sale_layout_category_hide_detail/views/sale_portal_templates.xml
@@ -70,7 +70,7 @@
                                 t-if="current_section.show_section_subtotal"
                                 class="text-end"
                                 t-out="current_subtotal"
-                                t-options='{"widget": "monetary", "display_currency": sale_order.pricelist_id.currency_id}'
+                                t-options='{"widget": "monetary", "display_currency": sale_order.currency_id}'
                             />
             </span>
           </td>


### PR DESCRIPTION
### Context
- Printing sale quotation in Sale or Portal, get this error

![sample_error_report](https://github.com/trisdoan/sale-reporting/assets/88806544/9be491c6-1b98-45c4-9135-7b80678414ef)

### Result
![result](https://github.com/jeroenev/sale-reporting/assets/88806544/f17ac9f2-8b7d-416d-b295-9f6bab89a618)

### This change
- In report template, access directly to currency_id in model `sale.report`